### PR TITLE
Moved min support from iOS 9 to 12

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,5 +1,5 @@
 # Global configuration
-platform :ios, '9.0'
+platform :ios, '12.0'
 use_frameworks!
 
 target 'XNLoggerTests' do

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Network loggers can generate huge data specially when binary data(like image, vi
 
 ## Requirements
 
-iOS 9.0 or later
+iOS 12.0 or later
 
 # Installation
 ## Cocoapods

--- a/XNLogger.podspec
+++ b/XNLogger.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "XNLogger"
-  s.version      = "2.3.1"
+  s.version      = "3.0.0"
   s.summary      = "Network Logger - Framework to log network traffics"
   s.description  = <<-DESC 
   XNLogger is simple and extensible network traffic logger. It makes easy to log network request and response on file, Xcode console or send log to servers. It provides user friendly UI for debugging and testing purpose. 

--- a/XNLogger.xcodeproj/project.pbxproj
+++ b/XNLogger.xcodeproj/project.pbxproj
@@ -463,7 +463,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1130;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = "Sunil Sharma";
 				TargetAttributes = {
 					1005805D21C65F490020288D = {
@@ -690,7 +690,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -752,7 +751,6 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_MODULE_NAME = "$(PRODUCT_NAME)";
@@ -779,6 +777,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = XNLogger/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -807,6 +806,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = XNLogger/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -828,6 +828,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = XNLoggerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -847,6 +848,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = "$(inherited)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = XNLoggerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/XNLogger.xcodeproj/xcshareddata/xcschemes/XNLogger.xcscheme
+++ b/XNLogger.xcodeproj/xcshareddata/xcschemes/XNLogger.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/XNLogger/Core/Filters/XNFilter.swift
+++ b/XNLogger/Core/Filters/XNFilter.swift
@@ -31,7 +31,7 @@ public enum XNFilterType {
     }
 }
 
-@objc public protocol XNFilter: class {
+@objc public protocol XNFilter: AnyObject {
     
     var invert: Bool { get set }
     func isAllowed(urlRequest: URLRequest) -> Bool

--- a/XNLogger/Core/Logger/LogHandlers/XNLogHandler.swift
+++ b/XNLogger/Core/Logger/LogHandlers/XNLogHandler.swift
@@ -11,7 +11,7 @@ import Foundation
 /**
  Log handler protocol. All log handler must adopt this protocol.
  */
-@objc public protocol XNLogHandler: class {
+@objc public protocol XNLogHandler: AnyObject {
     
     @objc optional func xnLogger(logRequest logData: XNLogData)
     @objc optional func xnLogger(logResponse logData: XNLogData)

--- a/XNLogger/Core/Models/XNLogData.swift
+++ b/XNLogger/Core/Models/XNLogData.swift
@@ -35,7 +35,11 @@ public enum XNSessionState: Int {
  XNLogData model is exposed as READ only i.e. variables can be read from
  outside module but variables cannot be WRITTEN or UPDATED from outside of module.
  */
-public class XNLogData: NSObject, NSCoding {
+public class XNLogData: NSObject, NSSecureCoding {
+    
+    public static var supportsSecureCoding: Bool {
+        return true
+    }
     
     public let identifier: String
     public let urlRequest: URLRequest
@@ -107,7 +111,7 @@ public class XNLogData: NSObject, NSCoding {
         let ms = Int((timeInterval.truncatingRemainder(dividingBy: 1)) * 1000)
         
         readableStr = "\(ms)ms"
-        /** Currently formatting in unnecessary
+        /** Currently formatting is unnecessary
         // Seconds
         let s = Int(timeInterval) % 60
         // Minutes
@@ -159,23 +163,24 @@ public class XNLogData: NSObject, NSCoding {
     }
     
     public required init?(coder aDecoder: NSCoder) {
-        guard let identifier = aDecoder.decodeObject(forKey: Key.identifier.rawValue) as? String,
-        let urlRequest = aDecoder.decodeObject(forKey: Key.urlRequest.rawValue) as? URLRequest
+        
+        guard let identifier = aDecoder.decodeObject(of: NSString.self, forKey: Key.identifier.rawValue) as? String,
+              let urlRequest = aDecoder.decodeObject(of: NSURLRequest.self ,forKey: Key.urlRequest.rawValue) as? URLRequest
         else { return nil }
         
         self.identifier = identifier
         self.urlRequest = urlRequest
         
-        self.response = aDecoder.decodeObject(forKey: Key.response.rawValue) as? URLResponse
-        self.receivedData = aDecoder.decodeObject(forKey: Key.receivedData.rawValue) as? Data
-        self.error = aDecoder.decodeObject(forKey: Key.error.rawValue) as? Error
-        self.startTime = aDecoder.decodeObject(forKey: Key.startTime.rawValue) as? Date
-        self.endTime = aDecoder.decodeObject(forKey: Key.endTime.rawValue) as? Date
-        self.redirectRequest = aDecoder.decodeObject(forKey: Key.redirectRequest.rawValue) as? URLRequest
-        if let stateRawValue = aDecoder.decodeObject(forKey: Key.state.rawValue) as? Int {
+        self.response = aDecoder.decodeObject(of: URLResponse.self ,forKey: Key.response.rawValue)
+        self.receivedData = aDecoder.decodeObject(of: NSData.self ,forKey: Key.receivedData.rawValue) as? Data
+        self.error = aDecoder.decodeObject(of: NSError.self ,forKey: Key.error.rawValue)
+        self.startTime = aDecoder.decodeObject(of: NSDate.self ,forKey: Key.startTime.rawValue) as? Date
+        self.endTime = aDecoder.decodeObject(of: NSDate.self ,forKey: Key.endTime.rawValue) as? Date
+        self.redirectRequest = aDecoder.decodeObject(of: NSURLRequest.self ,forKey: Key.redirectRequest.rawValue) as? URLRequest
+        if let stateRawValue = aDecoder.decodeObject(of: NSNumber.self ,forKey: Key.state.rawValue)?.intValue {
             self.state = XNSessionState(rawValue: stateRawValue)
         }
-        self.duration = aDecoder.decodeObject(forKey: Key.duration.rawValue) as? Double
+        self.duration = aDecoder.decodeObject(of: NSNumber.self ,forKey: Key.duration.rawValue)?.doubleValue
         
     }
     

--- a/XNLogger/Core/XNLogger.swift
+++ b/XNLogger/Core/XNLogger.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objc public protocol XNLoggerDelegate: class {
+@objc public protocol XNLoggerDelegate: AnyObject {
     
     @objc optional func xnLogger(didStartRequest logData: XNLogData)
     @objc optional func xnLogger(didReceiveResponse logData: XNLogData)

--- a/XNLogger/UI/LogDetailScreen/XNUILogDetailVC.swift
+++ b/XNLogger/UI/LogDetailScreen/XNUILogDetailVC.swift
@@ -42,7 +42,6 @@ class XNUILogDetailVC: XNUIBaseViewController {
         super.viewDidLoad()
         
         edgesForExtendedLayout = []
-        automaticallyAdjustsScrollViewInsets = false
         NotificationCenter.default.addObserver(self, selector: #selector(didReceiveUpdate(_:)), name: .logDataUpdate, object: nil)
         
         configureViews()
@@ -120,6 +119,7 @@ class XNUILogDetailVC: XNUIBaseViewController {
             /*Avoid UI update from other request notifications*/
             logId == logInfo?.identifier
             else { return }
+        
         loadData {[weak self] in
             DispatchQueue.main.safeAsync {
                 self?.updateUI()

--- a/XNLogger/UI/LogDetailScreen/XNUILogDetailView.swift
+++ b/XNLogger/UI/LogDetailScreen/XNUILogDetailView.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol XNUIDetailViewDelegate: class {
+protocol XNUIDetailViewDelegate: AnyObject {
     func showMessageFullScreen(logData: XNUIMessageData, title: String)
 }
 
@@ -67,6 +67,12 @@ class XNUILogDetailView: UIView, NibLoadableView {
         self.logDetailsTableView.register(ofType: XNUILogDetailCell.self)
         self.logDetailsTableView.dataSource = self
         self.logDetailsTableView.delegate = self
+        self.logDetailsTableView.contentInsetAdjustmentBehavior = .never
+        if #available(iOS 15.0, *) {
+            self.logDetailsTableView.sectionHeaderTopPadding = 0
+        } else {
+            // Fallback on earlier versions
+        }
     }
     
     func upadteView(with logDetails: [XNUILogDetail]) {

--- a/XNLogger/UI/SettingsScreen/XNUISettingsVC.swift
+++ b/XNLogger/UI/SettingsScreen/XNUISettingsVC.swift
@@ -160,7 +160,7 @@ extension XNUISettingsVC: UITableViewDelegate, UITableViewDataSource {
         
         if item.type == .help, let helpUrl = URL(string: "https://github.com/sunilsharma08/XNLogger") {
             if UIApplication.shared.canOpenURL(helpUrl) {
-                UIApplication.shared.openURL(helpUrl)
+                UIApplication.shared.open(helpUrl)
             }
         }
         DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {

--- a/XNLogger/UI/XNUIManager.swift
+++ b/XNLogger/UI/XNUIManager.swift
@@ -16,7 +16,7 @@ public enum XNGestureType: Int {
     case none
 }
 
-protocol XNUILogDataDelegate: class {
+protocol XNUILogDataDelegate: AnyObject {
     func receivedLogData(_ logData: XNLogData, isResponse: Bool)
 }
 

--- a/XNLogger/UI/XNUIPopOverViewController.swift
+++ b/XNLogger/UI/XNUIPopOverViewController.swift
@@ -58,8 +58,7 @@ class XNUIPopOverViewController: UIViewController {
             maxPopoverSize = CGSize(width: maxPopoverWidth, height: maxPopoverHeight)
         }
         self.view.addSubview(itemsTableView)
-        self.automaticallyAdjustsScrollViewInsets = false
-        
+        self.itemsTableView.contentInsetAdjustmentBehavior = .automatic
         itemsTableView.clipsToBounds = true
         itemsTableView.translatesAutoresizingMaskIntoConstraints = false
         itemsTableView.showsVerticalScrollIndicator = false

--- a/XNLoggerExample/XNLoggerExample.xcodeproj/project.pbxproj
+++ b/XNLoggerExample/XNLoggerExample.xcodeproj/project.pbxproj
@@ -219,7 +219,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 1010;
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1420;
 				ORGANIZATIONNAME = "Sunil Sharma";
 				TargetAttributes = {
 					10A9493A2335FAD40055C326 = {
@@ -398,7 +398,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -455,7 +455,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
@@ -476,6 +476,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = XNLoggerExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -500,6 +501,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = XNLoggerExample/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -519,6 +521,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = XNLoggerExampleTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -538,6 +541,7 @@
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
 				INFOPLIST_FILE = XNLoggerExampleTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/XNLoggerExample/XNLoggerExample.xcodeproj/xcshareddata/xcschemes/XNLoggerExample.xcscheme
+++ b/XNLoggerExample/XNLoggerExample.xcodeproj/xcshareddata/xcschemes/XNLoggerExample.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1420"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
- Moved minimum support from iOS 9 to 12
- Enabled secure encoding for log data
- Removed deprecated class and methods
- Updated project settings